### PR TITLE
Alter validation of phone numbers and edit test cases

### DIFF
--- a/src/main/java/bloodnet/model/person/Phone.java
+++ b/src/main/java/bloodnet/model/person/Phone.java
@@ -12,8 +12,8 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers should only contain numbers, and it should be 8 digits long.";
+    public static final String VALIDATION_REGEX = "\\d{8}";
     public final String value;
 
     /**

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -1,7 +1,7 @@
 {
   "persons": [ {
     "name": "Valid Person",
-    "phone": "9482424",
+    "phone": "94824242",
     "email": "hans@example.com",
     "address": "4th street"
   }, {

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
@@ -1,7 +1,7 @@
 {
   "persons": [ {
     "name": "Person with invalid name field: Ha!ns Mu@ster",
-    "phone": "9482424",
+    "phone": "94824242",
     "email": "hans@example.com",
     "address": "4th street"
   } ]

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -1,7 +1,7 @@
 {
   "persons": [ {
     "name": "Hans Muster",
-    "phone": "9482424",
+    "phone": "94782424",
     "email": "invalid@email!3e",
     "address": "4th street"
   } ]

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -26,19 +26,19 @@
     "tags" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
-    "phone" : "9482224",
+    "phone" : "94822242",
     "email" : "werner@example.com",
     "bloodType": "O-",
     "tags" : [ ]
   }, {
     "name" : "Fiona Kunz",
-    "phone" : "9482427",
+    "phone" : "94824271",
     "email" : "lydia@example.com",
     "bloodType": "O+",
     "tags" : [ ]
   }, {
     "name" : "George Best",
-    "phone" : "9482442",
+    "phone" : "94824422",
     "email" : "anna@example.com",
     "bloodType": "AB+",
     "tags" : [ ]

--- a/src/test/java/bloodnet/logic/parser/ParserUtilTest.java
+++ b/src/test/java/bloodnet/logic/parser/ParserUtilTest.java
@@ -28,7 +28,7 @@ public class ParserUtilTest {
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = "Rachel Walker";
-    private static final String VALID_PHONE = "123456";
+    private static final String VALID_PHONE = "12345678";
     private static final String VALID_BLOOD_TYPE = "B+";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";

--- a/src/test/java/bloodnet/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/bloodnet/model/person/NameContainsKeywordsPredicateTest.java
@@ -70,7 +70,7 @@ public class NameContainsKeywordsPredicateTest {
 
         // Keywords match phone, email and address, but does not match name
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345678")
                 .withEmail("alice@email.com").withBloodType("A+").build()));
     }
 

--- a/src/test/java/bloodnet/model/person/PhoneTest.java
+++ b/src/test/java/bloodnet/model/person/PhoneTest.java
@@ -31,19 +31,22 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
+        assertFalse(Phone.isValidPhone("911")); //too short numbers
+        assertFalse(Phone.isValidPhone("1232142141242142")); //too long numbers
+
 
         // valid phone numbers
-        assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
+        assertTrue(Phone.isValidPhone("91145678")); // exactly 3 numbers
         assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("12429444")); // long phone numbers
     }
 
     @Test
     public void equals() {
-        Phone phone = new Phone("999");
+        Phone phone = new Phone("99912345");
 
         // same values -> returns true
-        assertTrue(phone.equals(new Phone("999")));
+        assertTrue(phone.equals(new Phone("99912345")));
 
         // same object -> returns true
         assertTrue(phone.equals(phone));
@@ -55,6 +58,6 @@ public class PhoneTest {
         assertFalse(phone.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(phone.equals(new Phone("995")));
+        assertFalse(phone.equals(new Phone("99512345")));
     }
 }

--- a/src/test/java/bloodnet/testutil/TypicalPersons.java
+++ b/src/test/java/bloodnet/testutil/TypicalPersons.java
@@ -35,17 +35,17 @@ public class TypicalPersons {
             .withEmail("heinz@example.com").withBloodType("B+").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withBloodType("B-").withTags("friends").build();
-    public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
+    public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("94822242")
             .withEmail("werner@example.com").withBloodType("O-").build();
-    public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
+    public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("94824271")
             .withEmail("lydia@example.com").withBloodType("O+").build();
-    public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
+    public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("94824422")
             .withEmail("anna@example.com").withBloodType("AB+").build();
 
     // Manually added
-    public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
+    public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("84842424")
             .withEmail("stefan@example.com").withBloodType("B+").build();
-    public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
+    public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("84842131")
             .withEmail("hans@example.com").withBloodType("B+").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}


### PR DESCRIPTION
Since our app is catered towards Singapore blood donation companies, I decided to limit the number of digits inside of the phone number field to only accept 8 digits. Any other ways to enter a phone number are not accepted. 

I edited the test cases to match the new requirement. This fixes #47. 