### PR TITLE
Fix editdonation tests

### DIFF
--- a/src/main/java/bloodnet/model/donationrecord/DonationRecord.java
+++ b/src/main/java/bloodnet/model/donationrecord/DonationRecord.java
@@ -82,8 +82,7 @@ public class DonationRecord {
         }
 
         DonationRecord otherDonationRecord = (DonationRecord) other;
-        return id.equals(otherDonationRecord.id)
-                && personId.equals(otherDonationRecord.personId)
+        return personId.equals(otherDonationRecord.personId)
                 && donationDate.equals(otherDonationRecord.donationDate)
                 && bloodVolume.equals(otherDonationRecord.bloodVolume);
     }


### PR DESCRIPTION
Fixes #119 

- Make `editdonation` execution tests more in accordance to the rest of the codebase.
- Make `editdonation` execution success test, test the execution effects on model and the success message