### PR TITLE
Fix bug in DeleteDonationCommand to use full personList

### DIFF
--- a/src/main/java/bloodnet/logic/commands/DeleteDonationCommand.java
+++ b/src/main/java/bloodnet/logic/commands/DeleteDonationCommand.java
@@ -105,7 +105,7 @@ public class DeleteDonationCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        for (Person person : model.getFilteredPersonList()) {
+        for (Person person : model.getBloodNet().getPersonList()) {
             if (person.getId().equals(personId)) {
                 return person;
             }


### PR DESCRIPTION
Current implementation of getPersonForDonation assumes that:

∀ donationRecord ∈ displayed filtered donationRecordList, ∃ the donor corresponding to that donationRecord ∈ displayed filtered personList.

Which is not always true.